### PR TITLE
logger: add structured error carrying log fields for context

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,6 +14,7 @@
 package logger
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -76,7 +77,7 @@ var (
 	counterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "logger_logs_total",
 		Help: "Numbers of logs including warnings",
-	}, []string{"component", "level"})
+	}, []string{priv.LabelComponent, "level"})
 
 	rootCounterForPanic = counterVec.WithLabelValues("(root)", string(PanicLevel))
 	rootCounterForFatal = counterVec.WithLabelValues("(root)", string(FatalLevel))
@@ -85,6 +86,8 @@ var (
 	rootCounterForInfo  = counterVec.WithLabelValues("(root)", string(InfoLevel))
 	rootCounterForDebug = counterVec.WithLabelValues("(root)", string(DebugLevel))
 	rootCounterForTrace = counterVec.WithLabelValues("(root)", string(TraceLevel))
+
+	root = wrapRootLogger(logrus.NewEntry(logrus.New()))
 )
 
 func init() {
@@ -99,11 +102,11 @@ func SetAutoFormat() {
 	colorYN := strings.ToLower(os.Getenv("LOG_COLOR"))
 	switch colorYN {
 	case "1", "true", "y", "yes", "on":
-		priv.RootLogger.SetFormatter(priv.NewConsoleLogFormatter(true, priv.TextFormatter))
+		root.entry.Logger.SetFormatter(priv.NewConsoleLogFormatter(true, priv.TextFormatter))
 	case "0", "false", "n", "no", "off":
-		priv.RootLogger.SetFormatter(priv.TextFormatter)
+		root.entry.Logger.SetFormatter(priv.TextFormatter)
 	case "", "auto":
-		priv.RootLogger.SetFormatter(priv.NewConsoleLogFormatter(false, priv.TextFormatter))
+		root.entry.Logger.SetFormatter(priv.NewConsoleLogFormatter(false, priv.TextFormatter))
 	default:
 		Fatal("Invalid log color mode: \"" + colorYN + "\"")
 	}
@@ -114,7 +117,7 @@ func SetAutoFormat() {
 //     {"timestamp":"2006/02/01T15:04:05.123+0200","level":"info","message":"A group of walrus emerges from theocean"}
 //
 func SetJSONFormat() {
-	priv.RootLogger.SetFormatter(priv.JSONFormatter)
+	root.entry.Logger.SetFormatter(priv.JSONFormatter)
 }
 
 // SetTextFormat sets the default text format. For example:
@@ -122,7 +125,7 @@ func SetJSONFormat() {
 //    time="2006/02/01T15:04:05.123+0200" level=debug msg="Started observing beach"
 //
 func SetTextFormat() {
-	priv.RootLogger.SetFormatter(priv.TextFormatter)
+	root.entry.Logger.SetFormatter(priv.TextFormatter)
 }
 
 // SetDefaultLevel sets the default logging level depending on environment variable "LOG_LEVEL"
@@ -141,12 +144,12 @@ func SetLogLevel(level LogLevel) {
 	if !exists {
 		Fatal("Invalid log level: \"" + string(level) + "\"")
 	}
-	priv.RootLogger.SetLevel(logrusLevel)
+	root.entry.Logger.SetLevel(logrusLevel)
 }
 
 // SetOutput configures the root logger to output into specified Writer
 func SetOutput(output io.Writer) {
-	priv.RootLogger.SetOutput(output)
+	root.entry.Logger.SetOutput(output)
 }
 
 // SetOutputFile configure the root logger to write into specified file
@@ -178,7 +181,7 @@ func SetUpstreamEndpoint(endpoint string) {
 	} else {
 		hook = priv.NewUpstreamTCPBufferedHook(endpoint)
 	}
-	priv.RootLogger.Hooks.Add(hook)
+	root.entry.Logger.Hooks.Add(hook)
 }
 
 func isLocalhost(host string) bool {
@@ -210,123 +213,90 @@ func Exit(code int) {
  *****************************************************************************/
 
 // Root gets the root logger that can be used to create sub-loggers.
+//
 // Calling global logging functions in the package is the same as calling methods in the root logger.
-// The function always returns a new wrapper of the current underlying RootLogger from priv package.
 func Root() Logger {
-	entry := logrus.NewEntry(priv.RootLogger)
-	return wrapRootLogger(entry)
+	return root
 }
 
 // Panic logs critical errors and exits the program
 func Panic(args ...interface{}) {
-	rootCounterForPanic.Inc()
-	priv.RootLogger.Panic(args...)
+	root.Panic(args...)
 }
 
 // Panicf logs critical errors with formatting and exits the program
 func Panicf(format string, args ...interface{}) {
-	rootCounterForPanic.Inc()
-	priv.RootLogger.Panicf(format, args...)
+	root.Panicf(format, args...)
 }
 
 // Fatal logs critical errros
 func Fatal(args ...interface{}) {
-	rootCounterForFatal.Inc()
-	priv.RootLogger.Fatal(args...)
+	root.Fatal(args...)
 }
 
 // Fatalf logs critical errros with formatting
 func Fatalf(format string, args ...interface{}) {
-	rootCounterForFatal.Inc()
-	priv.RootLogger.Fatalf(format, args...)
+	root.Fatalf(format, args...)
 }
 
 // Error logs errors via the root logger
 func Error(args ...interface{}) {
-	rootCounterForError.Inc()
-	priv.RootLogger.Error(args...)
+	root.Error(args...)
 }
 
 // Errorf logs errors with formatting
 func Errorf(format string, args ...interface{}) {
-	rootCounterForError.Inc()
-	priv.RootLogger.Errorf(format, args...)
+	root.Errorf(format, args...)
 }
 
 // Warn logs warnings
 func Warn(args ...interface{}) {
-	rootCounterForWarn.Inc()
-	priv.RootLogger.Warn(args...)
+	root.Warn(args...)
 }
 
 // Warnf logs warnings with formatting
 func Warnf(format string, args ...interface{}) {
-	rootCounterForWarn.Inc()
-	priv.RootLogger.Warnf(format, args...)
+	root.Warnf(format, args...)
 }
 
 // Info logs information
 func Info(args ...interface{}) {
-	rootCounterForInfo.Inc()
-	priv.RootLogger.Info(args...)
+	root.Info(args...)
 }
 
 // Infof logs information with formatting
 func Infof(format string, args ...interface{}) {
-	rootCounterForInfo.Inc()
-	priv.RootLogger.Infof(format, args...)
-}
-
-// Print logs without logging level
-func Print(args ...interface{}) {
-	priv.RootLogger.Print(args...)
-}
-
-// Printf logs without logging level with formatting
-func Printf(format string, args ...interface{}) {
-	priv.RootLogger.Printf(format, args...)
+	root.Infof(format, args...)
 }
 
 // Debug logs debugging information
 func Debug(args ...interface{}) {
-	rootCounterForDebug.Inc()
-	priv.RootLogger.Debug(args...)
+	root.Debug(args...)
 }
 
 // Debugf logs debugging information with formatting
 func Debugf(format string, args ...interface{}) {
-	rootCounterForDebug.Inc()
-	priv.RootLogger.Debugf(format, args...)
+	root.Debugf(format, args...)
 }
 
 // Trace logs tracing information
 func Trace(args ...interface{}) {
-	rootCounterForTrace.Inc()
-	priv.RootLogger.Trace(args...)
+	root.Trace(args...)
 }
 
 // Tracef logs tracing information with formatting
 func Tracef(format string, args ...interface{}) {
-	rootCounterForTrace.Inc()
-	priv.RootLogger.Tracef(format, args...)
+	root.Tracef(format, args...)
 }
 
 // WithFields creates a sub-logger from the root logger with specifid fields
 func WithFields(fields map[string]interface{}) Logger {
-	entry := priv.RootLogger.WithFields(fields)
-	if component, hasComponent := fields["component"]; hasComponent {
-		return wrapLoggerWithNewComponent(entry, component)
-	}
-	return wrapRootLogger(entry)
+	return root.WithFields(fields)
 }
 
 // WithField creates a sub-logger from the root logger with specifid field
 func WithField(key string, value interface{}) Logger {
-	entry := priv.RootLogger.WithField(key, value)
-	if key == "component" {
-		return wrapLoggerWithNewComponent(entry, value)
-	}
-	return wrapRootLogger(entry)
+	return root.WithField(key, value)
 }
 
 /*****************************************************************************
@@ -336,110 +306,92 @@ func WithField(key string, value interface{}) Logger {
 // Panic logs critical errors and exits the program
 func (logger Logger) Panic(args ...interface{}) {
 	logger.counterForPanic.Inc()
-	logger.entry.Panic(args...)
+	getMergedEntryFromArgs(logger.entry, args).Panic(args...)
 }
 
 // Panicf logs critical errors with formatting and exits the program
 func (logger Logger) Panicf(format string, args ...interface{}) {
 	logger.counterForPanic.Inc()
-	logger.entry.Panicf(format, args...)
+	getMergedEntryFromArgs(logger.entry, args).Panicf(format, args...)
 }
 
 // Fatal logs critical errros
 func (logger Logger) Fatal(args ...interface{}) {
 	logger.counterForFatal.Inc()
-	logger.entry.Fatal(args...)
+	getMergedEntryFromArgs(logger.entry, args).Fatal(args...)
 }
 
 // Fatalf logs critical errros with formatting
 func (logger Logger) Fatalf(format string, args ...interface{}) {
 	logger.counterForFatal.Inc()
-	logger.entry.Fatalf(format, args...)
+	getMergedEntryFromArgs(logger.entry, args).Fatalf(format, args...)
 }
 
 // Error logs errors via the root logger
 func (logger Logger) Error(args ...interface{}) {
 	logger.counterForError.Inc()
-	logger.entry.Error(args...)
+	getMergedEntryFromArgs(logger.entry, args).Error(args...)
 }
 
 // Errorf logs errors with formatting
 func (logger Logger) Errorf(format string, args ...interface{}) {
 	logger.counterForError.Inc()
-	logger.entry.Errorf(format, args...)
+	getMergedEntryFromArgs(logger.entry, args).Errorf(format, args...)
 }
 
 // Warn logs warnings
 func (logger Logger) Warn(args ...interface{}) {
 	logger.counterForWarn.Inc()
-	logger.entry.Warn(args...)
+	getMergedEntryFromArgs(logger.entry, args).Warn(args...)
 }
 
 // Warnf logs warnings with formatting
 func (logger Logger) Warnf(format string, args ...interface{}) {
 	logger.counterForWarn.Inc()
-	logger.entry.Warnf(format, args...)
+	getMergedEntryFromArgs(logger.entry, args).Warnf(format, args...)
 }
 
 // Info logs information
 func (logger Logger) Info(args ...interface{}) {
 	logger.counterForInfo.Inc()
-	logger.entry.Info(args...)
+	getMergedEntryFromArgs(logger.entry, args).Info(args...)
 }
 
 // Infof logs information with formatting
 func (logger Logger) Infof(format string, args ...interface{}) {
 	logger.counterForInfo.Inc()
-	logger.entry.Infof(format, args...)
+	getMergedEntryFromArgs(logger.entry, args).Infof(format, args...)
 }
 
 // Debug logs debugging information
 func (logger Logger) Debug(args ...interface{}) {
 	logger.counterForDebug.Inc()
-	logger.entry.Debug(args...)
+	getMergedEntryFromArgs(logger.entry, args).Debug(args...)
 }
 
 // Debugf logs debugging information with formatting
 func (logger Logger) Debugf(format string, args ...interface{}) {
 	logger.counterForDebug.Inc()
-	logger.entry.Debugf(format, args...)
+	getMergedEntryFromArgs(logger.entry, args).Debugf(format, args...)
 }
 
 // Trace logs tracing information
 func (logger Logger) Trace(args ...interface{}) {
 	logger.counterForTrace.Inc()
-	logger.entry.Trace(args...)
+	getMergedEntryFromArgs(logger.entry, args).Trace(args...)
 }
 
 // Tracef logs tracing information with formatting
 func (logger Logger) Tracef(format string, args ...interface{}) {
 	logger.counterForTrace.Inc()
-	logger.entry.Tracef(format, args...)
-}
-
-// WithFields creates a sub-logger with specifid fields
-func (logger Logger) WithFields(fields map[string]interface{}) Logger {
-	entry := logger.entry.WithFields(fields)
-	if component, hasComponent := fields["component"]; hasComponent {
-		return wrapLoggerWithNewComponent(entry, component)
-	}
-	return wrapLogger(entry, logger)
-}
-
-// WithField creates a sub-logger with specifid field
-func (logger Logger) WithField(key string, value interface{}) Logger {
-	entry := logger.entry.WithField(key, value)
-	if key == "component" {
-		return wrapLoggerWithNewComponent(entry, value)
-	}
-	return wrapLogger(entry, logger)
+	getMergedEntryFromArgs(logger.entry, args).Tracef(format, args...)
 }
 
 // Sprint prints the given arguments with fields in this logger to a string
 //
 // e.g. "[MyClass] name=Foo status=200 My message"
 func (logger Logger) Sprint(args ...interface{}) string {
-	strList := logger.buildSprintPrefixes()
+	strList := buildSprintPrefixes(getMergedEntryFromArgs(logger.entry, args).Data)
 
 	if s := fmt.Sprint(args...); len(s) > 0 {
 		strList = append(strList, s)
@@ -452,7 +404,7 @@ func (logger Logger) Sprint(args ...interface{}) string {
 //
 // e.g. "[MyClass] name=Foo status=200  Hi '<someone>'"
 func (logger Logger) Sprintf(format string, args ...interface{}) string {
-	strList := logger.buildSprintPrefixes()
+	strList := buildSprintPrefixes(getMergedEntryFromArgs(logger.entry, args).Data)
 
 	if s := fmt.Sprintf(format, args...); len(s) > 0 {
 		strList = append(strList, s)
@@ -461,15 +413,54 @@ func (logger Logger) Sprintf(format string, args ...interface{}) string {
 	return strings.Join(strList, " ")
 }
 
-func (logger Logger) buildSprintPrefixes() []string {
+// Eprint prints the given arguments with fields in this logger to a StructuredError
+//
+// Fields in the logger are copied into StructuredError for later logging
+func (logger Logger) Eprint(args ...interface{}) error {
+	return NewStructuredError(logger.entry.Data, errors.New(fmt.Sprint(args...)))
+}
+
+// Eprintf formats the given arguments with fields in this logger to a StructuredError
+//
+// Fields in the logger are copied into StructuredError for later logging
+func (logger Logger) Eprintf(format string, args ...interface{}) error {
+	return NewStructuredError(logger.entry.Data, fmt.Errorf(format, args...))
+}
+
+// Ewrap wraps the given error inside a newly-created StructuredError with context information
+//
+// Fields in the logger are copied into StructuredError for later logging
+func (logger Logger) Ewrap(innerError error) error {
+	return NewStructuredError(logger.entry.Data, innerError)
+}
+
+// WithField creates a sub-logger with specifid field
+func (logger Logger) WithField(key string, value interface{}) Logger {
+	entry := logger.entry.WithField(key, value)
+	if key == priv.LabelComponent {
+		return wrapLoggerWithNewComponent(entry, value)
+	}
+	return wrapLogger(entry, logger)
+}
+
+// WithFields creates a sub-logger with specifid fields
+func (logger Logger) WithFields(fields map[string]interface{}) Logger {
+	entry := logger.entry.WithFields(fields)
+	if component, hasComponent := fields[priv.LabelComponent]; hasComponent {
+		return wrapLoggerWithNewComponent(entry, component)
+	}
+	return wrapLogger(entry, logger)
+}
+
+func buildSprintPrefixes(fields map[string]interface{}) []string {
 	prefixList := make([]string, 0, 3)
 
-	comp, hasComp := logger.entry.Data[priv.LabelComponent]
+	comp, hasComp := fields[priv.LabelComponent]
 	if hasComp {
 		prefixList = append(prefixList, fmt.Sprintf("[%v]", comp))
 	}
 
-	if dataStr := priv.FormatFields(logger.entry.Data); len(dataStr) > 0 {
+	if dataStr := priv.FormatFields(fields); len(dataStr) > 0 {
 		prefixList = append(prefixList, dataStr)
 	}
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -15,6 +15,7 @@ package logger
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -79,7 +80,7 @@ func TestConsoleLogger(t *testing.T) {
 
 func TestFallbackTextLogger(t *testing.T) {
 	before()
-	priv.RootLogger.SetFormatter(priv.NewConsoleLogFormatter(false, nil))
+	root.entry.Logger.SetFormatter(priv.NewConsoleLogFormatter(false, nil))
 	WithFields(Fields{
 		"path_with_quote_nospace": "\"hello\"", // shouldn't be quoted
 		"path_with_quote":         "\"hello world\"",
@@ -148,7 +149,7 @@ func TestForwardBuffered(t *testing.T) {
 	doneChannel := make(chan bool)
 	// start without listener, let forwarding fail and be retried
 	endpoint := "127.0.0.1:51400"
-	priv.RootLogger.Hooks.Add(priv.NewUpstreamTCPBufferedHook(endpoint))
+	root.entry.Logger.Hooks.Add(priv.NewUpstreamTCPBufferedHook(endpoint))
 	before()
 	Info("Hey there!")
 	Error("WTF!")
@@ -215,6 +216,28 @@ func TestFormat(t *testing.T) {
 		"name":   "Foo Bar",
 		"status": 123,
 	}).Sprint("hey", 456, "there"))
+}
+
+func TestStructuredError(t *testing.T) {
+	insideError := WithFields(Fields{
+		priv.LabelComponent: "Inside",
+		"url":               "http://not-here/x",
+		"status":            404,
+	}).Eprintf("something %s", "bad")
+
+	assert.Equal(t, `errorComponent=Inside status=404 url=http://not-here/x something bad`,
+		fmt.Sprint(insideError))
+
+	outsideLogger := WithFields(Fields{
+		priv.LabelComponent: "Outside",
+		"host":              "server1.com",
+		"url":               "http://not here",
+	})
+
+	assert.Equal(t, `[Outside] errorComponent=Inside host=server1.com status=404 url=http://not-here/x got an error: something bad`,
+		outsideLogger.Sprintf("got an error: %v", insideError))
+
+	assert.True(t, errors.Is(outsideLogger.Ewrap(os.ErrNotExist), os.ErrNotExist))
 }
 
 func startUpstreamListener(endpoint string, logCollector chan string, maxLogs int, doneChannel chan bool) {

--- a/logger/priv/consolelog.go
+++ b/logger/priv/consolelog.go
@@ -111,7 +111,7 @@ func (f *ConsoleLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 	strHead := formatAnsi(fmt.Sprintf("%-12s %-5s", entry.Time.Format(shortTimestamp), levelStr), levelColor, ansiBold)
 	if comp, ok := entry.Data[LabelComponent]; ok {
-		strHead = strHead + " " + formatAnsi(fmt.Sprintf("%v", comp), levelColor, ansiUnderline)
+		strHead = strHead + " " + formatAnsi(fmt.Sprint(comp), levelColor, ansiUnderline)
 	}
 	strBody := formatAnsi(entry.Message, levelColor)
 	strTail := ""
@@ -158,7 +158,7 @@ func FormatFields(fields logrus.Fields) string {
 		if key == LabelComponent {
 			continue
 		}
-		v := fmt.Sprintf("%v", fields[key])
+		v := fmt.Sprint(fields[key])
 		if strings.Contains(v, " ") {
 			fieldStrings = append(fieldStrings, fmt.Sprintf("%s=\"%s\"", key, fieldsFormatReplacer.Replace(v)))
 		} else {
@@ -177,7 +177,7 @@ func formatFieldsColored(fields logrus.Fields, color string) string {
 		}
 		val := fields[key]
 		fieldStrings = append(fieldStrings, formatAnsi(fmt.Sprintf("%s=", key), color, ansiItalic, ansiDimmed)+
-			formatAnsi(fmt.Sprintf("%v", val), color, ansiItalic))
+			formatAnsi(fmt.Sprint(val), color, ansiItalic))
 	}
 	return strings.Join(fieldStrings, " ")
 }

--- a/logger/priv/internal.go
+++ b/logger/priv/internal.go
@@ -41,8 +41,4 @@ var (
 		FullTimestamp:   true,
 		DisableColors:   true,
 	}
-
-	// RootLogger exposes the internal logrus root logger
-	// Reassignment of this field only affects subsequent calls to global logging functions (e.g. .Info and .Root), not existing loggers.
-	RootLogger = logrus.New()
 )

--- a/logger/structurederror.go
+++ b/logger/structurederror.go
@@ -1,0 +1,66 @@
+package logger
+
+import (
+	"strings"
+
+	"github.com/relex/gotils/logger/priv"
+	"github.com/sirupsen/logrus"
+)
+
+// getMergedEntryFromArgs scans the given arguments and make merged logger from the first StructuredError if present
+func getMergedEntryFromArgs(parent *logrus.Entry, args []interface{}) *logrus.Entry {
+	for i, a := range args {
+		if serr, ok := a.(*StructuredError); ok {
+			args[i] = serr.Unwrap()
+			return serr.getEntry(parent)
+		}
+	}
+
+	return parent
+}
+
+// StructuredError represents a thing that carries metadata that should be elevated to log fields when logged
+type StructuredError struct {
+	fields map[string]interface{}
+	err    error
+}
+
+// NewStructuredError creates a StructuredError with a map of fields (to be copied) and a message
+func NewStructuredError(srcFields map[string]interface{}, err error) *StructuredError {
+	newFields := make(map[string]interface{}, len(srcFields))
+	for k, v := range srcFields {
+		if k == priv.LabelComponent {
+			k = "errorComponent"
+		}
+		newFields[k] = v
+	}
+
+	return &StructuredError{
+		fields: newFields,
+		err:    err,
+	}
+}
+
+func (se *StructuredError) Error() string {
+	return se.String()
+}
+
+func (se *StructuredError) String() string {
+	strList := buildSprintPrefixes(se.fields)
+	if se.err != nil {
+		strList = append(strList, se.err.Error())
+	}
+	return strings.Join(strList, " ")
+}
+
+func (se *StructuredError) Unwrap() error {
+	return se.err
+}
+
+func (se *StructuredError) getEntry(parent *logrus.Entry) *logrus.Entry {
+	if len(se.fields) == 0 {
+		return parent
+	}
+
+	return parent.WithFields(se.fields)
+}


### PR DESCRIPTION
Usage: allow inner functions to return errors containing context information from logger, which can then be logged with combined information by its callers; see logger_test.go:TestStructuredError