### PR TITLE
Support date parsing in config/structargs

### DIFF
--- a/config/flagext/time.go
+++ b/config/flagext/time.go
@@ -10,6 +10,11 @@ import (
 
 type timeValue time.Time
 
+const (
+	localDateLayout = "2006-01-02"
+	localTimeLayout = "2006-01-02T15:04:05"
+)
+
 func newTimeValue(val time.Time, p *time.Time) *timeValue {
 	*p = val
 	return (*timeValue)(p)
@@ -17,10 +22,24 @@ func newTimeValue(val time.Time, p *time.Time) *timeValue {
 
 func (i *timeValue) String() string { return time.Time(*i).String() }
 func (i *timeValue) Set(s string) error {
-	tm, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(s))
+	var tm time.Time
+	var err error
+
+	s = strings.TrimSpace(s)
+
+	switch {
+	case len(s) == len(localDateLayout):
+		tm, err = time.ParseInLocation(localDateLayout, s, time.Local)
+	case len(s) == len(localTimeLayout):
+		tm, err = time.ParseInLocation(localTimeLayout, s, time.Local)
+	default:
+		tm, err = time.Parse(time.RFC3339Nano, s)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to parse time '%s': %w", s, err)
 	}
+
 	*i = timeValue(tm)
 	return nil
 }

--- a/config/flagext/time_test.go
+++ b/config/flagext/time_test.go
@@ -18,3 +18,16 @@ func TestTimeVar(t *testing.T) {
 	assert.Nil(t, f.Parse([]string{"--start", "2021-01-02T03:04:05.567Z"}))
 	assert.Equal(t, "2021-01-02T03:04:05.567Z", tm.Format(time.RFC3339Nano))
 }
+
+func TestTimeParse(t *testing.T) {
+	{
+		var tm timeValue
+		assert.Nil(t, tm.Set("2020-12-31"))
+		assert.Equal(t, time.Time(tm).Format(time.RFC3339Nano), time.Date(2020, 12, 31, 0, 0, 0, 0, time.Local).Format(time.RFC3339Nano))
+	}
+	{
+		var tm timeValue
+		assert.Nil(t, tm.Set("2020-12-31T10:30:15"))
+		assert.Equal(t, time.Time(tm).Format(time.RFC3339Nano), time.Date(2020, 12, 31, 10, 30, 15, 0, time.Local).Format(time.RFC3339Nano))
+	}
+}


### PR DESCRIPTION
config/structargs: support local date and local time in flags without using full format