### PR TITLE
scripts: Remove interfacer from make lint

### DIFF
--- a/templates/.golangci.yml
+++ b/templates/.golangci.yml
@@ -22,7 +22,7 @@ linters:
     - gocyclo
     - goprintffuncname
     # - gosec # CANNOT use until gosec options can be configured here: https://github.com/golangci/golangci-lint/issues/177
-    - interfacer
+    # - interfacer # WRONG warnings and deprecated by the author https://github.com/golangci/golangci-lint/issues/1689
     - prealloc
     # - scopelint # OUTDATED
     - unconvert


### PR DESCRIPTION
It fails this:

```go
    type Something interface {}
    type SomethingWithExtra interface {
        Something
        Extra()
    }

    func doSomething(s SomethingWithExtra) *Obj {
        return &Obj{
          extra: wrap(s.Extra),
          s:     s.Something,
        }
        // warning that says s should be Something (without Extra)
    }
```