### PR TITLE
Upgrade tools for go 1.18 generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.vscode
 /BUILD/*
 test_cache

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ install:
 
 .PHONY: uninstall
 uninstall:
+	rm -f ${GOPATH}/bin/{genny,exhaustivestruct,go-junit-report,scopelint,golint,shadow,staticcheck,golangci-lint}
 	rm -f ${GOPATH}/bin/gotils-*.sh
 	rm -fr ${GOPATH}/opt/gotils
 

--- a/scripts/gotils-prereq.sh
+++ b/scripts/gotils-prereq.sh
@@ -16,13 +16,12 @@
 GOPATH=$(go env GOPATH) || exit 1
 
 read -r -d '' DEPS << EndOfDef
-github.com/cheekybits/genny@v1.0.0
-github.com/jiping-s/exhaustivestruct/cmd/exhaustivestruct@master
-github.com/jstemmer/go-junit-report
-github.com/kyoh86/scopelint
-golang.org/x/lint/golint
-golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
-honnef.co/go/tools/cmd/staticcheck@2020.2.1
+github.com/jiping-s/exhaustivestruct/cmd/exhaustivestruct@v1.1.1
+github.com/jstemmer/go-junit-report@v1.0.0
+github.com/kyoh86/scopelint@latest
+golang.org/x/lint/golint@latest
+golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
+honnef.co/go/tools/cmd/staticcheck@2022.1.2
 EndOfDef
 
 export GO111MODULE=on
@@ -34,12 +33,12 @@ do
     BASENAME=${URL##*/}
     BINNAME=${BASENAME%%@*}
     echo "Check tool $BINNAME ..."
-    test -x $GOPATH/bin/$BINNAME || go get -u $URL
+    test -x $GOPATH/bin/$BINNAME || go install $URL
     ls -l $GOPATH/bin/$BINNAME
 done
 
 # Install golangci-lint, build broken
-GOLANGCI_VER=1.36.0
+GOLANGCI_VER=1.46.2
 TARGET_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 TARGET_CPU=$(uname -m | sed 's/x86_64/amd64/g')
 GOLANGCI_PKGNAME="golangci-lint-$GOLANGCI_VER-$TARGET_OS-$TARGET_CPU"


### PR DESCRIPTION
golangci-lint can't check generics yet