### PR TITLE
fix redis set values for custom type

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -60,7 +60,11 @@ func (cache redisCache[T]) Get(key string) (*T, error) {
 }
 
 func (cache redisCache[T]) Set(key string, value T, expiration time.Duration) error {
-	err := cache.client.Set(ctx, key, value, expiration).Err()
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	err = cache.client.Set(ctx, key, bytes, expiration).Err()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes `redis: can't marshal <Your Custom type name> (implement encoding.BinaryMarshaler)` error.
all custom types should have marshaler method BinaryMarshaler, I offer to convert data to `[]bytes` right before uploading and avoid redis prebuilt convertation 