### PR TITLE
Add AddMetrics function for default gatherer

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -13,7 +13,6 @@ import (
 type Cache[T any] interface {
 	Get(key string) (*T, error)
 	Set(key string, value T, expiration time.Duration) error
-	Del(key string) error
 	HealthCheck() error
 }
 
@@ -79,18 +78,6 @@ func (cache redisCache[T]) HealthCheck() error {
 	}
 	if val != "PONG" {
 		err := fmt.Errorf("received an invalid response to PING from redis")
-		return err
-	}
-	return nil
-}
-
-func (cache redisCache[T]) Del(keys string) error {
-	val, err := cache.client.Del(ctx, keys).Result()
-	if err != nil {
-		return err
-	}
-	if val == 0 {
-		err := fmt.Errorf("nothing to delete with key(s): %s", keys)
 		return err
 	}
 	return nil

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -13,6 +13,7 @@ import (
 type Cache[T any] interface {
 	Get(key string) (*T, error)
 	Set(key string, value T, expiration time.Duration) error
+	Del(key string) error
 	HealthCheck() error
 }
 
@@ -78,6 +79,18 @@ func (cache redisCache[T]) HealthCheck() error {
 	}
 	if val != "PONG" {
 		err := fmt.Errorf("received an invalid response to PING from redis")
+		return err
+	}
+	return nil
+}
+
+func (cache redisCache[T]) Del(keys string) error {
+	val, err := cache.client.Del(ctx, keys).Result()
+	if err != nil {
+		return err
+	}
+	if val == 0 {
+		err := fmt.Errorf("nothing to delete with key(s): %s", keys)
 		return err
 	}
 	return nil

--- a/promexporter/push.go
+++ b/promexporter/push.go
@@ -35,3 +35,16 @@ func PushMetrics(url string, job string) {
 		logger.Error("failed to push metrics: ", err)
 	}
 }
+
+// AddMetrics pushes all metrics in the default registry to the target URL
+// without overriding previously pushed metrics for this job
+//
+// The URL should contain no path for the official pushgateway
+func AddMetrics(url string, job string) {
+	client := &http.Client{}
+	client.Timeout = pushMetricsTimeout // default is no timeout
+	err := push.New(url, job).Gatherer(prometheus.DefaultGatherer).Client(client).Add()
+	if err != nil {
+		logger.Error("failed to push metrics: ", err)
+	}
+}


### PR DESCRIPTION
Want to suggest to add this function, because existing PushMetrics deletes all previous pushed metrics and keeps only default bunch. 
This should append default go app metrics to custom ones for that job